### PR TITLE
Add Image Upload Functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the Presentation Builder project will be documented in this file.
 
+## [0.2.0] - 2025-05-12
+
+### Added
+- Image upload functionality:
+  - Custom `ImageUpload` component for file selection and preview
+  - Support for uploading different images based on template type
+  - Image preview in editing modal
+  - Remove/replace options for uploaded images
+  - Automatic placeholder fallback
+
+### Changed
+- Enhanced slide data structure to store image information
+- Improved edit modal with dedicated image upload section
+- Updated slide templates to use uploaded images when available
+
 ## [0.1.0] - 2025-05-12
 
 ### Added
@@ -31,7 +46,6 @@ All notable changes to the Presentation Builder project will be documented in th
 - Tailwind CSS for styling
 
 ## Future Planned Enhancements
-- Image upload functionality
 - Save/load presentations
 - Export to PDF/PowerPoint
 - User authentication

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,20 @@ All notable changes to the Presentation Builder project will be documented in th
 
 ### Added
 - Image upload functionality:
-  - Custom `ImageUpload` component for file selection and preview
+  - Clean, minimalist image upload component
   - Support for uploading different images based on template type
   - Image preview in editing modal
   - Remove/replace options for uploaded images
-  - Automatic placeholder fallback
+  - Simple gray placeholders for empty image slots
+- Toggle option to hide title overlays in image grid templates
+  - Image-only grid templates (9-grid and 4-grid) now default to no title overlay
+  - Option to toggle title display in slide editor
 
 ### Changed
 - Enhanced slide data structure to store image information
 - Improved edit modal with dedicated image upload section
 - Updated slide templates to use uploaded images when available
+- Simplified UI with cleaner placeholders and more intuitive controls
 
 ## [0.1.0] - 2025-05-12
 
@@ -41,7 +45,7 @@ All notable changes to the Presentation Builder project will be documented in th
 - Responsive layout with three-panel design
 
 ### Technical Notes
-- Using placeholder.com for image placeholders
+- Using placeholder colors for image placeholders
 - Single-component architecture with state management
 - Tailwind CSS for styling
 

--- a/src/App.js
+++ b/src/App.js
@@ -190,8 +190,47 @@ function PresentationBuilder() {
       return slide.images[position].url;
     }
     
-    // Otherwise use placeholder
-    return `https://via.placeholder.com/${defaultSize}`;
+    // Otherwise use good quality placeholder based on position and slide type
+    // This gives more professional placeholders that fit the context
+    const category = getPlaceholderCategory(slide.type, position);
+    return `https://source.unsplash.com/featured/?${category}&${defaultSize}`;
+  };
+
+  // Get appropriate placeholder category based on slide type and position
+  const getPlaceholderCategory = (slideType, position) => {
+    switch(slideType) {
+      case 'fullImage':
+        return 'business,modern';
+      case 'rightImage':
+      case 'leftImage':
+        return 'office,professional';
+      case 'rightGrid':
+        if (position === 'grid1') return 'teamwork';
+        if (position === 'grid2') return 'meeting';
+        if (position === 'grid3') return 'technology';
+        return 'business';
+      case 'splitVertical':
+        if (position === 'top') return 'architecture';
+        if (position === 'bottom') return 'design';
+        return 'business';
+      case 'imageGrid':
+        // Generate varied categories for the grid
+        const gridCategories = [
+          'workspace', 'creative', 'design',
+          'technology', 'modern', 'office',
+          'architecture', 'business', 'teamwork'
+        ];
+        const gridPosition = parseInt(position.replace('grid', '')) - 1;
+        return gridCategories[gridPosition] || 'business';
+      case 'fourGrid':
+        if (position === 'grid1') return 'design';
+        if (position === 'grid2') return 'workspace';
+        if (position === 'grid3') return 'architecture';
+        if (position === 'grid4') return 'technology';
+        return 'business';
+      default:
+        return 'business';
+    }
   };
 
   // Check if image is a placeholder (not custom uploaded)
@@ -668,7 +707,6 @@ function PresentationBuilder() {
                           placeholderSize="1200x675"
                           onImageChange={(imageData) => handleImageChange('main', imageData)}
                           className="h-full rounded overflow-hidden"
-                          label="Upload Image"
                         />
                       </div>
                     </div>
@@ -684,7 +722,6 @@ function PresentationBuilder() {
                           placeholderSize="600x675"
                           onImageChange={(imageData) => handleImageChange('main', imageData)}
                           className="h-full rounded overflow-hidden"
-                          label="Upload Image"
                         />
                       </div>
                     </div>
@@ -700,7 +737,6 @@ function PresentationBuilder() {
                           placeholderSize="600x675"
                           onImageChange={(imageData) => handleImageChange('main', imageData)}
                           className="h-full rounded overflow-hidden"
-                          label="Upload Image"
                         />
                       </div>
                     </div>
@@ -718,7 +754,6 @@ function PresentationBuilder() {
                             placeholderSize="600x225"
                             onImageChange={(imageData) => handleImageChange('grid1', imageData)}
                             className="h-32 rounded overflow-hidden"
-                            label="Upload Image"
                           />
                         </div>
                         <div>
@@ -728,7 +763,6 @@ function PresentationBuilder() {
                             placeholderSize="600x225"
                             onImageChange={(imageData) => handleImageChange('grid2', imageData)}
                             className="h-32 rounded overflow-hidden"
-                            label="Upload Image"
                           />
                         </div>
                         <div>
@@ -738,7 +772,6 @@ function PresentationBuilder() {
                             placeholderSize="600x225"
                             onImageChange={(imageData) => handleImageChange('grid3', imageData)}
                             className="h-32 rounded overflow-hidden"
-                            label="Upload Image"
                           />
                         </div>
                       </div>
@@ -757,7 +790,6 @@ function PresentationBuilder() {
                             placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('top', imageData)}
                             className="h-40 rounded overflow-hidden"
-                            label="Upload Image"
                           />
                         </div>
                         <div>
@@ -767,7 +799,6 @@ function PresentationBuilder() {
                             placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('bottom', imageData)}
                             className="h-40 rounded overflow-hidden"
-                            label="Upload Image"
                           />
                         </div>
                       </div>
@@ -787,7 +818,6 @@ function PresentationBuilder() {
                               placeholderSize="400x225"
                               onImageChange={(imageData) => handleImageChange(`grid${i+1}`, imageData)}
                               className="h-24 rounded overflow-hidden"
-                              label="Upload Image"
                             />
                           </div>
                         ))}
@@ -807,7 +837,6 @@ function PresentationBuilder() {
                             placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('grid1', imageData)}
                             className="h-40 rounded overflow-hidden"
-                            label="Upload Image"
                           />
                         </div>
                         <div>
@@ -817,7 +846,6 @@ function PresentationBuilder() {
                             placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('grid2', imageData)}
                             className="h-40 rounded overflow-hidden"
-                            label="Upload Image"
                           />
                         </div>
                         <div>
@@ -827,7 +855,6 @@ function PresentationBuilder() {
                             placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('grid3', imageData)}
                             className="h-40 rounded overflow-hidden"
-                            label="Upload Image"
                           />
                         </div>
                         <div>
@@ -837,7 +864,6 @@ function PresentationBuilder() {
                             placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('grid4', imageData)}
                             className="h-40 rounded overflow-hidden"
-                            label="Upload Image"
                           />
                         </div>
                       </div>

--- a/src/App.js
+++ b/src/App.js
@@ -124,6 +124,18 @@ function PresentationBuilder() {
     }
   };
 
+  // Get a gray shade for placeholders to ensure a consistent look
+  const getPlaceholderColor = (position) => {
+    // Using a simple algorithm to generate different shades of gray based on position
+    const positionIndex = typeof position === 'string' ? 
+      position.replace(/[^\d]/g, '') : // Extract digits from positions like 'grid1'
+      0;
+    
+    // Calculate a shade of gray, alternating between lighter and darker
+    const baseValue = 50 + (positionIndex * 5) % 20;
+    return `rgb(${baseValue}, ${baseValue}, ${baseValue})`;
+  };
+
   // Remove a slide
   const removeSlide = (index) => {
     const newSlides = [...slides];
@@ -181,56 +193,6 @@ function PresentationBuilder() {
         [position]: imageData
       }
     });
-  };
-
-  // Get image URL based on slide type and position
-  const getImageUrl = (slide, position, defaultSize = '600x400') => {
-    // If there's a custom image for this position, use it
-    if (slide.images && slide.images[position] && slide.images[position].url) {
-      return slide.images[position].url;
-    }
-    
-    // Otherwise use good quality placeholder based on position and slide type
-    // This gives more professional placeholders that fit the context
-    const category = getPlaceholderCategory(slide.type, position);
-    return `https://source.unsplash.com/featured/?${category}&${defaultSize}`;
-  };
-
-  // Get appropriate placeholder category based on slide type and position
-  const getPlaceholderCategory = (slideType, position) => {
-    switch(slideType) {
-      case 'fullImage':
-        return 'business,modern';
-      case 'rightImage':
-      case 'leftImage':
-        return 'office,professional';
-      case 'rightGrid':
-        if (position === 'grid1') return 'teamwork';
-        if (position === 'grid2') return 'meeting';
-        if (position === 'grid3') return 'technology';
-        return 'business';
-      case 'splitVertical':
-        if (position === 'top') return 'architecture';
-        if (position === 'bottom') return 'design';
-        return 'business';
-      case 'imageGrid':
-        // Generate varied categories for the grid
-        const gridCategories = [
-          'workspace', 'creative', 'design',
-          'technology', 'modern', 'office',
-          'architecture', 'business', 'teamwork'
-        ];
-        const gridPosition = parseInt(position.replace('grid', '')) - 1;
-        return gridCategories[gridPosition] || 'business';
-      case 'fourGrid':
-        if (position === 'grid1') return 'design';
-        if (position === 'grid2') return 'workspace';
-        if (position === 'grid3') return 'architecture';
-        if (position === 'grid4') return 'technology';
-        return 'business';
-      default:
-        return 'business';
-    }
   };
 
   // Check if image is a placeholder (not custom uploaded)
@@ -338,13 +300,17 @@ function PresentationBuilder() {
                       {/* Full Image Template */}
                       {slide.type === 'fullImage' && (
                         <div className="w-full h-full relative overflow-hidden">
-                          {/* Image with optional user uploaded image */}
+                          {/* Display uploaded image OR solid color for placeholder */}
                           <div className="absolute inset-0">
-                            <img 
-                              src={getImageUrl(slide, 'main', '1200x675')} 
-                              alt="Background image"
-                              className="w-full h-full object-cover opacity-60"
-                            />
+                            {slide.images?.main?.url ? (
+                              <img 
+                                src={slide.images.main.url} 
+                                alt="Background image"
+                                className="w-full h-full object-cover opacity-60"
+                              />
+                            ) : (
+                              <div className="w-full h-full bg-gray-800"></div>
+                            )}
                           </div>
                           
                           {/* Content overlay */}
@@ -380,13 +346,17 @@ function PresentationBuilder() {
                             </div>
                           </div>
                           
-                          {/* Right image section - with optional uploaded image */}
+                          {/* Right image section - with uploaded image or placeholder */}
                           <div className="w-1/2 bg-gray-800 relative">
-                            <img 
-                              src={getImageUrl(slide, 'main', '600x675')}
-                              alt="Right side image"
-                              className="w-full h-full object-cover opacity-70"
-                            />
+                            {slide.images?.main?.url ? (
+                              <img 
+                                src={slide.images.main.url}
+                                alt="Right side image"
+                                className="w-full h-full object-cover opacity-70"
+                              />
+                            ) : (
+                              <div className="w-full h-full bg-gray-700"></div>
+                            )}
                           </div>
                         </div>
                       )}
@@ -394,13 +364,17 @@ function PresentationBuilder() {
                       {/* Left Image Template */}
                       {slide.type === 'leftImage' && (
                         <div className="w-full h-full flex">
-                          {/* Left image section - with optional uploaded image */}
+                          {/* Left image section - with uploaded image or placeholder */}
                           <div className="w-1/2 bg-gray-800 relative">
-                            <img 
-                              src={getImageUrl(slide, 'main', '600x675')}
-                              alt="Left side image"
-                              className="w-full h-full object-cover opacity-70"
-                            />
+                            {slide.images?.main?.url ? (
+                              <img 
+                                src={slide.images.main.url}
+                                alt="Left side image"
+                                className="w-full h-full object-cover opacity-70"
+                              />
+                            ) : (
+                              <div className="w-full h-full bg-gray-700"></div>
+                            )}
                           </div>
                           
                           {/* Right content section */}
@@ -446,28 +420,49 @@ function PresentationBuilder() {
                             </div>
                           </div>
                           
-                          {/* Right image grid section - with optional uploaded images */}
+                          {/* Right image grid section - with uploaded images or placeholders */}
                           <div className="w-1/2 grid grid-cols-1 grid-rows-3 gap-1">
                             <div className="relative">
-                              <img 
-                                src={getImageUrl(slide, 'grid1', '600x225')}
-                                alt="Top grid image"
-                                className="w-full h-full object-cover"
-                              />
+                              {slide.images?.grid1?.url ? (
+                                <img 
+                                  src={slide.images.grid1.url}
+                                  alt="Top grid image"
+                                  className="w-full h-full object-cover"
+                                />
+                              ) : (
+                                <div 
+                                  className="w-full h-full" 
+                                  style={{backgroundColor: getPlaceholderColor('grid1')}}
+                                ></div>
+                              )}
                             </div>
                             <div className="relative">
-                              <img 
-                                src={getImageUrl(slide, 'grid2', '600x225')}
-                                alt="Middle grid image"
-                                className="w-full h-full object-cover"
-                              />
+                              {slide.images?.grid2?.url ? (
+                                <img 
+                                  src={slide.images.grid2.url}
+                                  alt="Middle grid image"
+                                  className="w-full h-full object-cover"
+                                />
+                              ) : (
+                                <div 
+                                  className="w-full h-full" 
+                                  style={{backgroundColor: getPlaceholderColor('grid2')}}
+                                ></div>
+                              )}
                             </div>
                             <div className="relative">
-                              <img 
-                                src={getImageUrl(slide, 'grid3', '600x225')}
-                                alt="Bottom grid image"
-                                className="w-full h-full object-cover"
-                              />
+                              {slide.images?.grid3?.url ? (
+                                <img 
+                                  src={slide.images.grid3.url}
+                                  alt="Bottom grid image"
+                                  className="w-full h-full object-cover"
+                                />
+                              ) : (
+                                <div 
+                                  className="w-full h-full" 
+                                  style={{backgroundColor: getPlaceholderColor('grid3')}}
+                                ></div>
+                              )}
                             </div>
                           </div>
                         </div>
@@ -488,21 +483,35 @@ function PresentationBuilder() {
                             </div>
                           </div>
                           
-                          {/* Right split image section - with optional uploaded images */}
+                          {/* Right split image section - with uploaded images or placeholders */}
                           <div className="w-1/2 grid grid-rows-2 gap-1">
                             <div className="relative">
-                              <img 
-                                src={getImageUrl(slide, 'top', '600x337')}
-                                alt="Top image"
-                                className="w-full h-full object-cover"
-                              />
+                              {slide.images?.top?.url ? (
+                                <img 
+                                  src={slide.images.top.url}
+                                  alt="Top image"
+                                  className="w-full h-full object-cover"
+                                />
+                              ) : (
+                                <div 
+                                  className="w-full h-full" 
+                                  style={{backgroundColor: getPlaceholderColor('top')}}
+                                ></div>
+                              )}
                             </div>
                             <div className="relative">
-                              <img 
-                                src={getImageUrl(slide, 'bottom', '600x337')}
-                                alt="Bottom image"
-                                className="w-full h-full object-cover"
-                              />
+                              {slide.images?.bottom?.url ? (
+                                <img 
+                                  src={slide.images.bottom.url}
+                                  alt="Bottom image"
+                                  className="w-full h-full object-cover"
+                                />
+                              ) : (
+                                <div 
+                                  className="w-full h-full" 
+                                  style={{backgroundColor: getPlaceholderColor('bottom')}}
+                                ></div>
+                              )}
                             </div>
                           </div>
                         </div>
@@ -514,11 +523,18 @@ function PresentationBuilder() {
                           <div className="grid grid-cols-3 grid-rows-3 gap-1 h-full">
                             {Array(9).fill(0).map((_, i) => (
                               <div key={i} className="relative">
-                                <img 
-                                  src={getImageUrl(slide, `grid${i+1}`, '400x225')}
-                                  alt={`Grid image ${i+1}`}
-                                  className="w-full h-full object-cover"
-                                />
+                                {slide.images?.[`grid${i+1}`]?.url ? (
+                                  <img 
+                                    src={slide.images[`grid${i+1}`].url}
+                                    alt={`Grid image ${i+1}`}
+                                    className="w-full h-full object-cover"
+                                  />
+                                ) : (
+                                  <div 
+                                    className="w-full h-full" 
+                                    style={{backgroundColor: getPlaceholderColor(`grid${i+1}`)}}
+                                  ></div>
+                                )}
                               </div>
                             ))}
                           </div>
@@ -535,32 +551,60 @@ function PresentationBuilder() {
                         <div className="w-full h-full">
                           <div className="grid grid-cols-2 grid-rows-2 gap-1 h-full">
                             <div className="relative">
-                              <img 
-                                src={getImageUrl(slide, 'grid1', '600x337')}
-                                alt="Top left image"
-                                className="w-full h-full object-cover"
-                              />
+                              {slide.images?.grid1?.url ? (
+                                <img 
+                                  src={slide.images.grid1.url}
+                                  alt="Top left image"
+                                  className="w-full h-full object-cover"
+                                />
+                              ) : (
+                                <div 
+                                  className="w-full h-full" 
+                                  style={{backgroundColor: getPlaceholderColor('grid1')}}
+                                ></div>
+                              )}
                             </div>
                             <div className="relative">
-                              <img 
-                                src={getImageUrl(slide, 'grid2', '600x337')}
-                                alt="Top right image"
-                                className="w-full h-full object-cover"
-                              />
+                              {slide.images?.grid2?.url ? (
+                                <img 
+                                  src={slide.images.grid2.url}
+                                  alt="Top right image"
+                                  className="w-full h-full object-cover"
+                                />
+                              ) : (
+                                <div 
+                                  className="w-full h-full" 
+                                  style={{backgroundColor: getPlaceholderColor('grid2')}}
+                                ></div>
+                              )}
                             </div>
                             <div className="relative">
-                              <img 
-                                src={getImageUrl(slide, 'grid3', '600x337')}
-                                alt="Bottom left image"
-                                className="w-full h-full object-cover"
-                              />
+                              {slide.images?.grid3?.url ? (
+                                <img 
+                                  src={slide.images.grid3.url}
+                                  alt="Bottom left image"
+                                  className="w-full h-full object-cover"
+                                />
+                              ) : (
+                                <div 
+                                  className="w-full h-full" 
+                                  style={{backgroundColor: getPlaceholderColor('grid3')}}
+                                ></div>
+                              )}
                             </div>
                             <div className="relative">
-                              <img 
-                                src={getImageUrl(slide, 'grid4', '600x337')}
-                                alt="Bottom right image"
-                                className="w-full h-full object-cover"
-                              />
+                              {slide.images?.grid4?.url ? (
+                                <img 
+                                  src={slide.images.grid4.url}
+                                  alt="Bottom right image"
+                                  className="w-full h-full object-cover"
+                                />
+                              ) : (
+                                <div 
+                                  className="w-full h-full" 
+                                  style={{backgroundColor: getPlaceholderColor('grid4')}}
+                                ></div>
+                              )}
                             </div>
                           </div>
                           
@@ -704,7 +748,6 @@ function PresentationBuilder() {
                       <div className="aspect-video max-h-80">
                         <ImageUpload
                           initialImage={editForm.images?.main?.url}
-                          placeholderSize="1200x675"
                           onImageChange={(imageData) => handleImageChange('main', imageData)}
                           className="h-full rounded overflow-hidden"
                         />
@@ -719,7 +762,6 @@ function PresentationBuilder() {
                       <div className="aspect-video max-h-80">
                         <ImageUpload
                           initialImage={editForm.images?.main?.url}
-                          placeholderSize="600x675"
                           onImageChange={(imageData) => handleImageChange('main', imageData)}
                           className="h-full rounded overflow-hidden"
                         />
@@ -734,7 +776,6 @@ function PresentationBuilder() {
                       <div className="aspect-video max-h-80">
                         <ImageUpload
                           initialImage={editForm.images?.main?.url}
-                          placeholderSize="600x675"
                           onImageChange={(imageData) => handleImageChange('main', imageData)}
                           className="h-full rounded overflow-hidden"
                         />
@@ -751,7 +792,6 @@ function PresentationBuilder() {
                           <div className="text-xs text-gray-500 mb-1">Top Image</div>
                           <ImageUpload
                             initialImage={editForm.images?.grid1?.url}
-                            placeholderSize="600x225"
                             onImageChange={(imageData) => handleImageChange('grid1', imageData)}
                             className="h-32 rounded overflow-hidden"
                           />
@@ -760,7 +800,6 @@ function PresentationBuilder() {
                           <div className="text-xs text-gray-500 mb-1">Middle Image</div>
                           <ImageUpload
                             initialImage={editForm.images?.grid2?.url}
-                            placeholderSize="600x225"
                             onImageChange={(imageData) => handleImageChange('grid2', imageData)}
                             className="h-32 rounded overflow-hidden"
                           />
@@ -769,7 +808,6 @@ function PresentationBuilder() {
                           <div className="text-xs text-gray-500 mb-1">Bottom Image</div>
                           <ImageUpload
                             initialImage={editForm.images?.grid3?.url}
-                            placeholderSize="600x225"
                             onImageChange={(imageData) => handleImageChange('grid3', imageData)}
                             className="h-32 rounded overflow-hidden"
                           />
@@ -787,7 +825,6 @@ function PresentationBuilder() {
                           <div className="text-xs text-gray-500 mb-1">Top Image</div>
                           <ImageUpload
                             initialImage={editForm.images?.top?.url}
-                            placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('top', imageData)}
                             className="h-40 rounded overflow-hidden"
                           />
@@ -796,7 +833,6 @@ function PresentationBuilder() {
                           <div className="text-xs text-gray-500 mb-1">Bottom Image</div>
                           <ImageUpload
                             initialImage={editForm.images?.bottom?.url}
-                            placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('bottom', imageData)}
                             className="h-40 rounded overflow-hidden"
                           />
@@ -815,7 +851,6 @@ function PresentationBuilder() {
                             <div className="text-xs text-gray-500 mb-1">Image {i+1}</div>
                             <ImageUpload
                               initialImage={editForm.images?.[`grid${i+1}`]?.url}
-                              placeholderSize="400x225"
                               onImageChange={(imageData) => handleImageChange(`grid${i+1}`, imageData)}
                               className="h-24 rounded overflow-hidden"
                             />
@@ -834,7 +869,6 @@ function PresentationBuilder() {
                           <div className="text-xs text-gray-500 mb-1">Top Left</div>
                           <ImageUpload
                             initialImage={editForm.images?.grid1?.url}
-                            placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('grid1', imageData)}
                             className="h-40 rounded overflow-hidden"
                           />
@@ -843,7 +877,6 @@ function PresentationBuilder() {
                           <div className="text-xs text-gray-500 mb-1">Top Right</div>
                           <ImageUpload
                             initialImage={editForm.images?.grid2?.url}
-                            placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('grid2', imageData)}
                             className="h-40 rounded overflow-hidden"
                           />
@@ -852,7 +885,6 @@ function PresentationBuilder() {
                           <div className="text-xs text-gray-500 mb-1">Bottom Left</div>
                           <ImageUpload
                             initialImage={editForm.images?.grid3?.url}
-                            placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('grid3', imageData)}
                             className="h-40 rounded overflow-hidden"
                           />
@@ -861,7 +893,6 @@ function PresentationBuilder() {
                           <div className="text-xs text-gray-500 mb-1">Bottom Right</div>
                           <ImageUpload
                             initialImage={editForm.images?.grid4?.url}
-                            placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('grid4', imageData)}
                             className="h-40 rounded overflow-hidden"
                           />

--- a/src/App.js
+++ b/src/App.js
@@ -90,6 +90,11 @@ function PresentationBuilder() {
         ];
       }
       
+      // For image grid templates, set showTitle to false
+      if (template.type === 'imageGrid' || template.type === 'fourGrid') {
+        newSlide.showTitle = false;
+      }
+      
       setSlides([...slides, newSlide]);
     }
   };
@@ -152,6 +157,7 @@ function PresentationBuilder() {
       content: slide.content || '',
       attribution: slide.attribution || '',
       bulletPoints: slide.bulletPoints || [],
+      showTitle: slide.showTitle !== undefined ? slide.showTitle : true,
       images: slide.images || {} // Include images in edit form
     });
   };
@@ -539,10 +545,12 @@ function PresentationBuilder() {
                             ))}
                           </div>
                           
-                          {/* Overlay title */}
-                          <div className="absolute inset-0 flex items-center justify-center">
-                            <h3 className="text-4xl font-bold text-white bg-gray-900 bg-opacity-70 px-6 py-3">{slide.title}</h3>
-                          </div>
+                          {/* Only show title overlay if showTitle is true */}
+                          {slide.showTitle !== false && (
+                            <div className="absolute inset-0 flex items-center justify-center">
+                              <h3 className="text-4xl font-bold text-white bg-gray-900 bg-opacity-70 px-6 py-3">{slide.title}</h3>
+                            </div>
+                          )}
                         </div>
                       )}
                       
@@ -608,10 +616,12 @@ function PresentationBuilder() {
                             </div>
                           </div>
                           
-                          {/* Overlay title */}
-                          <div className="absolute inset-0 flex items-center justify-center">
-                            <h3 className="text-4xl font-bold text-white bg-gray-900 bg-opacity-70 px-6 py-3">{slide.title}</h3>
-                          </div>
+                          {/* Only show title overlay if showTitle is true */}
+                          {slide.showTitle !== false && (
+                            <div className="absolute inset-0 flex items-center justify-center">
+                              <h3 className="text-4xl font-bold text-white bg-gray-900 bg-opacity-70 px-6 py-3">{slide.title}</h3>
+                            </div>
+                          )}
                         </div>
                       )}
                     </div>
@@ -734,6 +744,22 @@ function PresentationBuilder() {
                       onChange={(e) => setEditForm({...editForm, attribution: e.target.value})}
                       className="w-full px-3 py-2 border border-gray-300 rounded"
                     />
+                  </div>
+                )}
+                
+                {/* Title Display Option for Image Grid Templates */}
+                {(editingSlide.type === 'imageGrid' || editingSlide.type === 'fourGrid') && (
+                  <div className="flex items-center mt-2">
+                    <input
+                      type="checkbox"
+                      id="showTitle"
+                      checked={editForm.showTitle !== false}
+                      onChange={(e) => setEditForm({...editForm, showTitle: e.target.checked})}
+                      className="h-4 w-4 text-blue-600 border-gray-300 rounded mr-2"
+                    />
+                    <label htmlFor="showTitle" className="text-sm text-gray-700">
+                      Show title overlay
+                    </label>
                   </div>
                 )}
 

--- a/src/App.js
+++ b/src/App.js
@@ -667,8 +667,8 @@ function PresentationBuilder() {
                           initialImage={editForm.images?.main?.url}
                           placeholderSize="1200x675"
                           onImageChange={(imageData) => handleImageChange('main', imageData)}
-                          className="h-full rounded overflow-hidden border border-gray-300"
-                          label="Upload Background Image"
+                          className="h-full rounded overflow-hidden"
+                          label="Upload Image"
                         />
                       </div>
                     </div>
@@ -683,8 +683,8 @@ function PresentationBuilder() {
                           initialImage={editForm.images?.main?.url}
                           placeholderSize="600x675"
                           onImageChange={(imageData) => handleImageChange('main', imageData)}
-                          className="h-full rounded overflow-hidden border border-gray-300"
-                          label="Upload Right Image"
+                          className="h-full rounded overflow-hidden"
+                          label="Upload Image"
                         />
                       </div>
                     </div>
@@ -699,8 +699,8 @@ function PresentationBuilder() {
                           initialImage={editForm.images?.main?.url}
                           placeholderSize="600x675"
                           onImageChange={(imageData) => handleImageChange('main', imageData)}
-                          className="h-full rounded overflow-hidden border border-gray-300"
-                          label="Upload Left Image"
+                          className="h-full rounded overflow-hidden"
+                          label="Upload Image"
                         />
                       </div>
                     </div>
@@ -717,8 +717,8 @@ function PresentationBuilder() {
                             initialImage={editForm.images?.grid1?.url}
                             placeholderSize="600x225"
                             onImageChange={(imageData) => handleImageChange('grid1', imageData)}
-                            className="h-32 rounded overflow-hidden border border-gray-300"
-                            label="Upload"
+                            className="h-32 rounded overflow-hidden"
+                            label="Upload Image"
                           />
                         </div>
                         <div>
@@ -727,8 +727,8 @@ function PresentationBuilder() {
                             initialImage={editForm.images?.grid2?.url}
                             placeholderSize="600x225"
                             onImageChange={(imageData) => handleImageChange('grid2', imageData)}
-                            className="h-32 rounded overflow-hidden border border-gray-300"
-                            label="Upload"
+                            className="h-32 rounded overflow-hidden"
+                            label="Upload Image"
                           />
                         </div>
                         <div>
@@ -737,8 +737,8 @@ function PresentationBuilder() {
                             initialImage={editForm.images?.grid3?.url}
                             placeholderSize="600x225"
                             onImageChange={(imageData) => handleImageChange('grid3', imageData)}
-                            className="h-32 rounded overflow-hidden border border-gray-300"
-                            label="Upload"
+                            className="h-32 rounded overflow-hidden"
+                            label="Upload Image"
                           />
                         </div>
                       </div>
@@ -756,8 +756,8 @@ function PresentationBuilder() {
                             initialImage={editForm.images?.top?.url}
                             placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('top', imageData)}
-                            className="h-40 rounded overflow-hidden border border-gray-300"
-                            label="Upload Top Image"
+                            className="h-40 rounded overflow-hidden"
+                            label="Upload Image"
                           />
                         </div>
                         <div>
@@ -766,8 +766,8 @@ function PresentationBuilder() {
                             initialImage={editForm.images?.bottom?.url}
                             placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('bottom', imageData)}
-                            className="h-40 rounded overflow-hidden border border-gray-300"
-                            label="Upload Bottom Image"
+                            className="h-40 rounded overflow-hidden"
+                            label="Upload Image"
                           />
                         </div>
                       </div>
@@ -786,8 +786,8 @@ function PresentationBuilder() {
                               initialImage={editForm.images?.[`grid${i+1}`]?.url}
                               placeholderSize="400x225"
                               onImageChange={(imageData) => handleImageChange(`grid${i+1}`, imageData)}
-                              className="h-24 rounded overflow-hidden border border-gray-300"
-                              label="Upload"
+                              className="h-24 rounded overflow-hidden"
+                              label="Upload Image"
                             />
                           </div>
                         ))}
@@ -806,7 +806,7 @@ function PresentationBuilder() {
                             initialImage={editForm.images?.grid1?.url}
                             placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('grid1', imageData)}
-                            className="h-40 rounded overflow-hidden border border-gray-300"
+                            className="h-40 rounded overflow-hidden"
                             label="Upload Image"
                           />
                         </div>
@@ -816,7 +816,7 @@ function PresentationBuilder() {
                             initialImage={editForm.images?.grid2?.url}
                             placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('grid2', imageData)}
-                            className="h-40 rounded overflow-hidden border border-gray-300"
+                            className="h-40 rounded overflow-hidden"
                             label="Upload Image"
                           />
                         </div>
@@ -826,7 +826,7 @@ function PresentationBuilder() {
                             initialImage={editForm.images?.grid3?.url}
                             placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('grid3', imageData)}
-                            className="h-40 rounded overflow-hidden border border-gray-300"
+                            className="h-40 rounded overflow-hidden"
                             label="Upload Image"
                           />
                         </div>
@@ -836,7 +836,7 @@ function PresentationBuilder() {
                             initialImage={editForm.images?.grid4?.url}
                             placeholderSize="600x337"
                             onImageChange={(imageData) => handleImageChange('grid4', imageData)}
-                            className="h-40 rounded overflow-hidden border border-gray-300"
+                            className="h-40 rounded overflow-hidden"
                             label="Upload Image"
                           />
                         </div>

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { ChevronUp, ChevronDown, Edit2, Trash2, Image, Plus, Monitor, Type, Layout } from 'lucide-react';
+import ImageUpload from './components/ImageUpload';
 
 // Main App Component
 function PresentationBuilder() {
@@ -10,7 +11,9 @@ function PresentationBuilder() {
       type: 'fullImage',
       title: 'Your Title Here',
       subtitle: 'Subtitle Text Here',
-      attribution: 'Your Name / Company'
+      attribution: 'Your Name / Company',
+      // Default with no custom image
+      images: {}
     }
   ]);
   
@@ -18,7 +21,8 @@ function PresentationBuilder() {
   const [editForm, setEditForm] = useState({
     title: '',
     content: '',
-    attribution: ''
+    attribution: '',
+    images: {}
   });
 
   // Library of templates
@@ -68,7 +72,8 @@ function PresentationBuilder() {
         type: template.type,
         uniqueId: Date.now().toString(),
         title: getDefaultTitle(template.type),
-        content: getDefaultContent(template.type)
+        content: getDefaultContent(template.type),
+        images: {} // Initialize empty images object for all slide types
       };
       
       // Add specific properties based on slide type
@@ -134,7 +139,8 @@ function PresentationBuilder() {
       subtitle: slide.subtitle || '',
       content: slide.content || '',
       attribution: slide.attribution || '',
-      bulletPoints: slide.bulletPoints || []
+      bulletPoints: slide.bulletPoints || [],
+      images: slide.images || {} // Include images in edit form
     });
   };
 
@@ -164,6 +170,33 @@ function PresentationBuilder() {
     newSlides.splice(newIndex, 0, slideToMove);
     
     setSlides(newSlides);
+  };
+
+  // Handle image change from ImageUpload component
+  const handleImageChange = (position, imageData) => {
+    setEditForm({
+      ...editForm,
+      images: {
+        ...editForm.images,
+        [position]: imageData
+      }
+    });
+  };
+
+  // Get image URL based on slide type and position
+  const getImageUrl = (slide, position, defaultSize = '600x400') => {
+    // If there's a custom image for this position, use it
+    if (slide.images && slide.images[position] && slide.images[position].url) {
+      return slide.images[position].url;
+    }
+    
+    // Otherwise use placeholder
+    return `https://via.placeholder.com/${defaultSize}`;
+  };
+
+  // Check if image is a placeholder (not custom uploaded)
+  const isPlaceholderImage = (slide, position) => {
+    return !(slide.images && slide.images[position] && slide.images[position].url);
   };
 
   return (
@@ -266,11 +299,11 @@ function PresentationBuilder() {
                       {/* Full Image Template */}
                       {slide.type === 'fullImage' && (
                         <div className="w-full h-full relative overflow-hidden">
-                          {/* This is a real image element */}
+                          {/* Image with optional user uploaded image */}
                           <div className="absolute inset-0">
                             <img 
-                              src="https://via.placeholder.com/1200x675" 
-                              alt="Data center hallway"
+                              src={getImageUrl(slide, 'main', '1200x675')} 
+                              alt="Background image"
                               className="w-full h-full object-cover opacity-60"
                             />
                           </div>
@@ -308,11 +341,11 @@ function PresentationBuilder() {
                             </div>
                           </div>
                           
-                          {/* Right image section - this is a real image */}
+                          {/* Right image section - with optional uploaded image */}
                           <div className="w-1/2 bg-gray-800 relative">
                             <img 
-                              src="https://via.placeholder.com/600x675" 
-                              alt="Server room"
+                              src={getImageUrl(slide, 'main', '600x675')}
+                              alt="Right side image"
                               className="w-full h-full object-cover opacity-70"
                             />
                           </div>
@@ -322,11 +355,11 @@ function PresentationBuilder() {
                       {/* Left Image Template */}
                       {slide.type === 'leftImage' && (
                         <div className="w-full h-full flex">
-                          {/* Left image section - this is a real image */}
+                          {/* Left image section - with optional uploaded image */}
                           <div className="w-1/2 bg-gray-800 relative">
                             <img 
-                              src="https://via.placeholder.com/600x675" 
-                              alt="Tech worker"
+                              src={getImageUrl(slide, 'main', '600x675')}
+                              alt="Left side image"
                               className="w-full h-full object-cover opacity-70"
                             />
                           </div>
@@ -374,26 +407,26 @@ function PresentationBuilder() {
                             </div>
                           </div>
                           
-                          {/* Right image grid section - using real images */}
+                          {/* Right image grid section - with optional uploaded images */}
                           <div className="w-1/2 grid grid-cols-1 grid-rows-3 gap-1">
                             <div className="relative">
                               <img 
-                                src="https://via.placeholder.com/600x225" 
-                                alt="Lab notes"
+                                src={getImageUrl(slide, 'grid1', '600x225')}
+                                alt="Top grid image"
                                 className="w-full h-full object-cover"
                               />
                             </div>
                             <div className="relative">
                               <img 
-                                src="https://via.placeholder.com/600x225" 
-                                alt="Scientist"
+                                src={getImageUrl(slide, 'grid2', '600x225')}
+                                alt="Middle grid image"
                                 className="w-full h-full object-cover"
                               />
                             </div>
                             <div className="relative">
                               <img 
-                                src="https://via.placeholder.com/600x225" 
-                                alt="Close-up"
+                                src={getImageUrl(slide, 'grid3', '600x225')}
+                                alt="Bottom grid image"
                                 className="w-full h-full object-cover"
                               />
                             </div>
@@ -416,19 +449,19 @@ function PresentationBuilder() {
                             </div>
                           </div>
                           
-                          {/* Right split image section - using real images */}
+                          {/* Right split image section - with optional uploaded images */}
                           <div className="w-1/2 grid grid-rows-2 gap-1">
                             <div className="relative">
                               <img 
-                                src="https://via.placeholder.com/600x337" 
-                                alt="Office entrance"
+                                src={getImageUrl(slide, 'top', '600x337')}
+                                alt="Top image"
                                 className="w-full h-full object-cover"
                               />
                             </div>
                             <div className="relative">
                               <img 
-                                src="https://via.placeholder.com/600x337" 
-                                alt="Glass ceiling"
+                                src={getImageUrl(slide, 'bottom', '600x337')}
+                                alt="Bottom image"
                                 className="w-full h-full object-cover"
                               />
                             </div>
@@ -443,7 +476,7 @@ function PresentationBuilder() {
                             {Array(9).fill(0).map((_, i) => (
                               <div key={i} className="relative">
                                 <img 
-                                  src={`https://via.placeholder.com/400x225`} 
+                                  src={getImageUrl(slide, `grid${i+1}`, '400x225')}
                                   alt={`Grid image ${i+1}`}
                                   className="w-full h-full object-cover"
                                 />
@@ -464,29 +497,29 @@ function PresentationBuilder() {
                           <div className="grid grid-cols-2 grid-rows-2 gap-1 h-full">
                             <div className="relative">
                               <img 
-                                src="https://via.placeholder.com/600x337" 
-                                alt="Server corridor"
+                                src={getImageUrl(slide, 'grid1', '600x337')}
+                                alt="Top left image"
                                 className="w-full h-full object-cover"
                               />
                             </div>
                             <div className="relative">
                               <img 
-                                src="https://via.placeholder.com/600x337" 
-                                alt="Data center discussion"
+                                src={getImageUrl(slide, 'grid2', '600x337')}
+                                alt="Top right image"
                                 className="w-full h-full object-cover"
                               />
                             </div>
                             <div className="relative">
                               <img 
-                                src="https://via.placeholder.com/600x337" 
-                                alt="IT specialist"
+                                src={getImageUrl(slide, 'grid3', '600x337')}
+                                alt="Bottom left image"
                                 className="w-full h-full object-cover"
                               />
                             </div>
                             <div className="relative">
                               <img 
-                                src="https://via.placeholder.com/600x337" 
-                                alt="Tech working"
+                                src={getImageUrl(slide, 'grid4', '600x337')}
+                                alt="Bottom right image"
                                 className="w-full h-full object-cover"
                               />
                             </div>
@@ -527,7 +560,7 @@ function PresentationBuilder() {
       {/* Edit Modal */}
       {editingSlide && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-          <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl">
+          <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl max-h-screen overflow-y-auto">
             <div className="p-6">
               <h2 className="text-xl font-semibold mb-6">Edit Slide Content</h2>
               
@@ -620,6 +653,197 @@ function PresentationBuilder() {
                     />
                   </div>
                 )}
+
+                {/* Image Upload Section */}
+                <div className="mt-6">
+                  <h3 className="text-lg font-medium text-gray-900 mb-3">Images</h3>
+                  
+                  {/* Full Image Template */}
+                  {editingSlide.type === 'fullImage' && (
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">Background Image</label>
+                      <div className="aspect-video max-h-80">
+                        <ImageUpload
+                          initialImage={editForm.images?.main?.url}
+                          placeholderSize="1200x675"
+                          onImageChange={(imageData) => handleImageChange('main', imageData)}
+                          className="h-full rounded overflow-hidden border border-gray-300"
+                          label="Upload Background Image"
+                        />
+                      </div>
+                    </div>
+                  )}
+                  
+                  {/* Right Image Template */}
+                  {editingSlide.type === 'rightImage' && (
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">Right Side Image</label>
+                      <div className="aspect-video max-h-80">
+                        <ImageUpload
+                          initialImage={editForm.images?.main?.url}
+                          placeholderSize="600x675"
+                          onImageChange={(imageData) => handleImageChange('main', imageData)}
+                          className="h-full rounded overflow-hidden border border-gray-300"
+                          label="Upload Right Image"
+                        />
+                      </div>
+                    </div>
+                  )}
+                  
+                  {/* Left Image Template */}
+                  {editingSlide.type === 'leftImage' && (
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">Left Side Image</label>
+                      <div className="aspect-video max-h-80">
+                        <ImageUpload
+                          initialImage={editForm.images?.main?.url}
+                          placeholderSize="600x675"
+                          onImageChange={(imageData) => handleImageChange('main', imageData)}
+                          className="h-full rounded overflow-hidden border border-gray-300"
+                          label="Upload Left Image"
+                        />
+                      </div>
+                    </div>
+                  )}
+                  
+                  {/* Right Grid Template */}
+                  {editingSlide.type === 'rightGrid' && (
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">Grid Images</label>
+                      <div className="grid grid-cols-3 gap-3">
+                        <div>
+                          <div className="text-xs text-gray-500 mb-1">Top Image</div>
+                          <ImageUpload
+                            initialImage={editForm.images?.grid1?.url}
+                            placeholderSize="600x225"
+                            onImageChange={(imageData) => handleImageChange('grid1', imageData)}
+                            className="h-32 rounded overflow-hidden border border-gray-300"
+                            label="Upload"
+                          />
+                        </div>
+                        <div>
+                          <div className="text-xs text-gray-500 mb-1">Middle Image</div>
+                          <ImageUpload
+                            initialImage={editForm.images?.grid2?.url}
+                            placeholderSize="600x225"
+                            onImageChange={(imageData) => handleImageChange('grid2', imageData)}
+                            className="h-32 rounded overflow-hidden border border-gray-300"
+                            label="Upload"
+                          />
+                        </div>
+                        <div>
+                          <div className="text-xs text-gray-500 mb-1">Bottom Image</div>
+                          <ImageUpload
+                            initialImage={editForm.images?.grid3?.url}
+                            placeholderSize="600x225"
+                            onImageChange={(imageData) => handleImageChange('grid3', imageData)}
+                            className="h-32 rounded overflow-hidden border border-gray-300"
+                            label="Upload"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                  
+                  {/* Split Vertical Template */}
+                  {editingSlide.type === 'splitVertical' && (
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">Split Images</label>
+                      <div className="grid grid-cols-2 gap-3">
+                        <div>
+                          <div className="text-xs text-gray-500 mb-1">Top Image</div>
+                          <ImageUpload
+                            initialImage={editForm.images?.top?.url}
+                            placeholderSize="600x337"
+                            onImageChange={(imageData) => handleImageChange('top', imageData)}
+                            className="h-40 rounded overflow-hidden border border-gray-300"
+                            label="Upload Top Image"
+                          />
+                        </div>
+                        <div>
+                          <div className="text-xs text-gray-500 mb-1">Bottom Image</div>
+                          <ImageUpload
+                            initialImage={editForm.images?.bottom?.url}
+                            placeholderSize="600x337"
+                            onImageChange={(imageData) => handleImageChange('bottom', imageData)}
+                            className="h-40 rounded overflow-hidden border border-gray-300"
+                            label="Upload Bottom Image"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                  
+                  {/* Image Grid Template */}
+                  {editingSlide.type === 'imageGrid' && (
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">Grid Images</label>
+                      <div className="grid grid-cols-3 gap-2">
+                        {Array(9).fill(0).map((_, i) => (
+                          <div key={i}>
+                            <div className="text-xs text-gray-500 mb-1">Image {i+1}</div>
+                            <ImageUpload
+                              initialImage={editForm.images?.[`grid${i+1}`]?.url}
+                              placeholderSize="400x225"
+                              onImageChange={(imageData) => handleImageChange(`grid${i+1}`, imageData)}
+                              className="h-24 rounded overflow-hidden border border-gray-300"
+                              label="Upload"
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  
+                  {/* Four Grid Template */}
+                  {editingSlide.type === 'fourGrid' && (
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">Grid Images</label>
+                      <div className="grid grid-cols-2 gap-3">
+                        <div>
+                          <div className="text-xs text-gray-500 mb-1">Top Left</div>
+                          <ImageUpload
+                            initialImage={editForm.images?.grid1?.url}
+                            placeholderSize="600x337"
+                            onImageChange={(imageData) => handleImageChange('grid1', imageData)}
+                            className="h-40 rounded overflow-hidden border border-gray-300"
+                            label="Upload Image"
+                          />
+                        </div>
+                        <div>
+                          <div className="text-xs text-gray-500 mb-1">Top Right</div>
+                          <ImageUpload
+                            initialImage={editForm.images?.grid2?.url}
+                            placeholderSize="600x337"
+                            onImageChange={(imageData) => handleImageChange('grid2', imageData)}
+                            className="h-40 rounded overflow-hidden border border-gray-300"
+                            label="Upload Image"
+                          />
+                        </div>
+                        <div>
+                          <div className="text-xs text-gray-500 mb-1">Bottom Left</div>
+                          <ImageUpload
+                            initialImage={editForm.images?.grid3?.url}
+                            placeholderSize="600x337"
+                            onImageChange={(imageData) => handleImageChange('grid3', imageData)}
+                            className="h-40 rounded overflow-hidden border border-gray-300"
+                            label="Upload Image"
+                          />
+                        </div>
+                        <div>
+                          <div className="text-xs text-gray-500 mb-1">Bottom Right</div>
+                          <ImageUpload
+                            initialImage={editForm.images?.grid4?.url}
+                            placeholderSize="600x337"
+                            onImageChange={(imageData) => handleImageChange('grid4', imageData)}
+                            className="h-40 rounded overflow-hidden border border-gray-300"
+                            label="Upload Image"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
             

--- a/src/components/ImageUpload.js
+++ b/src/components/ImageUpload.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Upload, X, Image as ImageIcon } from 'lucide-react';
 
 /**
@@ -23,6 +23,17 @@ function ImageUpload({
   const [previewUrl, setPreviewUrl] = useState(initialImage || `https://via.placeholder.com/${placeholderSize}`);
   const [isPlaceholder, setIsPlaceholder] = useState(!initialImage);
   const fileInputRef = useRef(null);
+
+  // Reset state if initialImage changes
+  useEffect(() => {
+    if (initialImage) {
+      setPreviewUrl(initialImage);
+      setIsPlaceholder(false);
+    } else {
+      setPreviewUrl(`https://via.placeholder.com/${placeholderSize}`);
+      setIsPlaceholder(true);
+    }
+  }, [initialImage, placeholderSize]);
 
   const handleFileChange = (e) => {
     const file = e.target.files[0];
@@ -68,8 +79,14 @@ function ImageUpload({
   };
 
   const triggerFileInput = () => {
+    // Extra console log to debug
+    console.log("File input trigger clicked");
+    
     if (fileInputRef.current) {
+      console.log("File input ref exists, clicking it");
       fileInputRef.current.click();
+    } else {
+      console.log("File input ref is null");
     }
   };
 
@@ -109,7 +126,10 @@ function ImageUpload({
         
         {/* Placeholder overlay when no image */}
         {isPlaceholder && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center text-gray-400">
+          <div 
+            className="absolute inset-0 flex flex-col items-center justify-center text-gray-400 cursor-pointer"
+            onClick={triggerFileInput}
+          >
             <ImageIcon size={36} />
             <span className="mt-2 text-sm">{label}</span>
           </div>

--- a/src/components/ImageUpload.js
+++ b/src/components/ImageUpload.js
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Upload, X, Image as ImageIcon } from 'lucide-react';
+import { Upload, X } from 'lucide-react';
 
 /**
  * ImageUpload Component
@@ -11,14 +11,12 @@ import { Upload, X, Image as ImageIcon } from 'lucide-react';
  * @param {string} [props.placeholderSize='600x400'] - Size of placeholder image if no image is uploaded
  * @param {Function} props.onImageChange - Callback when image is selected/changed
  * @param {string} [props.className] - Additional CSS classes
- * @param {string} [props.label='Upload Image'] - Label text for the upload button
  */
 function ImageUpload({ 
   initialImage, 
   placeholderSize = '600x400',
   onImageChange, 
-  className = '', 
-  label = 'Upload Image' 
+  className = ''
 }) {
   const [previewUrl, setPreviewUrl] = useState(initialImage || null);
   const [isPlaceholder, setIsPlaceholder] = useState(!initialImage);
@@ -86,8 +84,11 @@ function ImageUpload({
 
   return (
     <div className={`relative group ${className}`}>
-      <div className="relative w-full h-full overflow-hidden bg-gray-100 rounded border border-gray-300">
-        {/* Only show image if we have a preview URL */}
+      <div 
+        className="relative w-full h-full overflow-hidden bg-gray-100 rounded border border-gray-300 cursor-pointer transition-all duration-200 hover:bg-gray-200"
+        onClick={triggerFileInput}
+      >
+        {/* If we have a preview URL, show the image */}
         {previewUrl ? (
           <img 
             src={previewUrl} 
@@ -95,43 +96,34 @@ function ImageUpload({
             className="w-full h-full object-cover"
           />
         ) : (
-          <div className="w-full h-full"></div>
+          // Otherwise show a nice gradient placeholder
+          <div className="w-full h-full bg-gradient-to-br from-gray-100 to-gray-300 flex items-center justify-center">
+            <Upload size={24} className="text-gray-500" />
+          </div>
         )}
         
-        {/* Overlay controls that show on hover */}
-        <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-30 transition-all flex items-center justify-center">
-          <div className="flex space-x-2">
-            <button
-              type="button"
-              onClick={triggerFileInput}
-              className="p-2 bg-white bg-opacity-90 rounded-full shadow hover:bg-opacity-100"
-              title="Upload Image"
-            >
+        {/* Hover effect */}
+        <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+          <div className="bg-black bg-opacity-40 w-full h-full flex items-center justify-center">
+            <div className="p-2 bg-white bg-opacity-90 rounded-full shadow">
               <Upload size={20} className="text-gray-800" />
-            </button>
-            
-            {!isPlaceholder && (
-              <button
-                type="button"
-                onClick={clearImage}
-                className="p-2 bg-white bg-opacity-90 rounded-full shadow hover:bg-opacity-100"
-                title="Remove image"
-              >
-                <X size={20} className="text-red-600" />
-              </button>
-            )}
+            </div>
           </div>
         </div>
         
-        {/* Placeholder overlay when no image */}
-        {isPlaceholder && (
-          <div 
-            className="absolute inset-0 flex flex-col items-center justify-center text-gray-400 cursor-pointer"
-            onClick={triggerFileInput}
+        {/* Remove button - only show if we have an image */}
+        {!isPlaceholder && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              clearImage();
+            }}
+            className="absolute top-2 right-2 p-1 bg-white bg-opacity-90 rounded-full shadow hover:bg-opacity-100 z-10"
+            title="Remove image"
           >
-            <ImageIcon size={36} />
-            <span className="mt-2 text-sm">{label}</span>
-          </div>
+            <X size={16} className="text-red-600" />
+          </button>
         )}
       </div>
       

--- a/src/components/ImageUpload.js
+++ b/src/components/ImageUpload.js
@@ -20,7 +20,7 @@ function ImageUpload({
   className = '', 
   label = 'Upload Image' 
 }) {
-  const [previewUrl, setPreviewUrl] = useState(initialImage || `https://via.placeholder.com/${placeholderSize}`);
+  const [previewUrl, setPreviewUrl] = useState(initialImage || null);
   const [isPlaceholder, setIsPlaceholder] = useState(!initialImage);
   const fileInputRef = useRef(null);
 
@@ -30,10 +30,10 @@ function ImageUpload({
       setPreviewUrl(initialImage);
       setIsPlaceholder(false);
     } else {
-      setPreviewUrl(`https://via.placeholder.com/${placeholderSize}`);
+      setPreviewUrl(null);
       setIsPlaceholder(true);
     }
-  }, [initialImage, placeholderSize]);
+  }, [initialImage]);
 
   const handleFileChange = (e) => {
     const file = e.target.files[0];
@@ -64,7 +64,7 @@ function ImageUpload({
 
   const clearImage = () => {
     // Reset to placeholder
-    setPreviewUrl(`https://via.placeholder.com/${placeholderSize}`);
+    setPreviewUrl(null);
     setIsPlaceholder(true);
     
     // Clear the file input
@@ -79,25 +79,24 @@ function ImageUpload({
   };
 
   const triggerFileInput = () => {
-    // Extra console log to debug
-    console.log("File input trigger clicked");
-    
     if (fileInputRef.current) {
-      console.log("File input ref exists, clicking it");
       fileInputRef.current.click();
-    } else {
-      console.log("File input ref is null");
     }
   };
 
   return (
     <div className={`relative group ${className}`}>
-      <div className="relative w-full h-full overflow-hidden">
-        <img 
-          src={previewUrl} 
-          alt="Selected preview" 
-          className={`w-full h-full object-cover ${isPlaceholder ? 'opacity-50' : ''}`}
-        />
+      <div className="relative w-full h-full overflow-hidden bg-gray-100 rounded border border-gray-300">
+        {/* Only show image if we have a preview URL */}
+        {previewUrl ? (
+          <img 
+            src={previewUrl} 
+            alt="Preview" 
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <div className="w-full h-full"></div>
+        )}
         
         {/* Overlay controls that show on hover */}
         <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-30 transition-all flex items-center justify-center">
@@ -106,7 +105,7 @@ function ImageUpload({
               type="button"
               onClick={triggerFileInput}
               className="p-2 bg-white bg-opacity-90 rounded-full shadow hover:bg-opacity-100"
-              title={label}
+              title="Upload Image"
             >
               <Upload size={20} className="text-gray-800" />
             </button>

--- a/src/components/ImageUpload.js
+++ b/src/components/ImageUpload.js
@@ -8,13 +8,11 @@ import { Upload, X } from 'lucide-react';
  * 
  * @param {Object} props
  * @param {string} [props.initialImage] - URL of initial image to display
- * @param {string} [props.placeholderSize='600x400'] - Size of placeholder image if no image is uploaded
  * @param {Function} props.onImageChange - Callback when image is selected/changed
  * @param {string} [props.className] - Additional CSS classes
  */
 function ImageUpload({ 
   initialImage, 
-  placeholderSize = '600x400',
   onImageChange, 
   className = ''
 }) {
@@ -85,7 +83,7 @@ function ImageUpload({
   return (
     <div className={`relative group ${className}`}>
       <div 
-        className="relative w-full h-full overflow-hidden bg-gray-100 rounded border border-gray-300 cursor-pointer transition-all duration-200 hover:bg-gray-200"
+        className="relative w-full h-full overflow-hidden bg-gray-100 rounded border border-gray-300 cursor-pointer transition-all duration-200 hover:bg-gray-200 flex items-center justify-center"
         onClick={triggerFileInput}
       >
         {/* If we have a preview URL, show the image */}
@@ -96,20 +94,9 @@ function ImageUpload({
             className="w-full h-full object-cover"
           />
         ) : (
-          // Otherwise show a nice gradient placeholder
-          <div className="w-full h-full bg-gradient-to-br from-gray-100 to-gray-300 flex items-center justify-center">
-            <Upload size={24} className="text-gray-500" />
-          </div>
+          // Empty placeholder with just an upload icon
+          <Upload size={24} className="text-gray-400" />
         )}
-        
-        {/* Hover effect */}
-        <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
-          <div className="bg-black bg-opacity-40 w-full h-full flex items-center justify-center">
-            <div className="p-2 bg-white bg-opacity-90 rounded-full shadow">
-              <Upload size={20} className="text-gray-800" />
-            </div>
-          </div>
-        </div>
         
         {/* Remove button - only show if we have an image */}
         {!isPlaceholder && (

--- a/src/components/ImageUpload.js
+++ b/src/components/ImageUpload.js
@@ -1,0 +1,131 @@
+import React, { useState, useRef } from 'react';
+import { Upload, X, Image as ImageIcon } from 'lucide-react';
+
+/**
+ * ImageUpload Component
+ * 
+ * A reusable component for handling image uploads with preview functionality
+ * 
+ * @param {Object} props
+ * @param {string} [props.initialImage] - URL of initial image to display
+ * @param {string} [props.placeholderSize='600x400'] - Size of placeholder image if no image is uploaded
+ * @param {Function} props.onImageChange - Callback when image is selected/changed
+ * @param {string} [props.className] - Additional CSS classes
+ * @param {string} [props.label='Upload Image'] - Label text for the upload button
+ */
+function ImageUpload({ 
+  initialImage, 
+  placeholderSize = '600x400',
+  onImageChange, 
+  className = '', 
+  label = 'Upload Image' 
+}) {
+  const [previewUrl, setPreviewUrl] = useState(initialImage || `https://via.placeholder.com/${placeholderSize}`);
+  const [isPlaceholder, setIsPlaceholder] = useState(!initialImage);
+  const fileInputRef = useRef(null);
+
+  const handleFileChange = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    // Validate file is an image
+    if (!file.type.startsWith('image/')) {
+      alert('Please select an image file');
+      return;
+    }
+
+    // Create a preview URL for the selected file
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+    setIsPlaceholder(false);
+
+    // Call the callback with the file and URL
+    if (onImageChange) {
+      onImageChange({
+        file,
+        url,
+        name: file.name,
+        size: file.size,
+        type: file.type
+      });
+    }
+  };
+
+  const clearImage = () => {
+    // Reset to placeholder
+    setPreviewUrl(`https://via.placeholder.com/${placeholderSize}`);
+    setIsPlaceholder(true);
+    
+    // Clear the file input
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+    
+    // Call callback with null to indicate clearing
+    if (onImageChange) {
+      onImageChange(null);
+    }
+  };
+
+  const triggerFileInput = () => {
+    if (fileInputRef.current) {
+      fileInputRef.current.click();
+    }
+  };
+
+  return (
+    <div className={`relative group ${className}`}>
+      <div className="relative w-full h-full overflow-hidden">
+        <img 
+          src={previewUrl} 
+          alt="Selected preview" 
+          className={`w-full h-full object-cover ${isPlaceholder ? 'opacity-50' : ''}`}
+        />
+        
+        {/* Overlay controls that show on hover */}
+        <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-30 transition-all flex items-center justify-center">
+          <div className="flex space-x-2">
+            <button
+              type="button"
+              onClick={triggerFileInput}
+              className="p-2 bg-white bg-opacity-90 rounded-full shadow hover:bg-opacity-100"
+              title={label}
+            >
+              <Upload size={20} className="text-gray-800" />
+            </button>
+            
+            {!isPlaceholder && (
+              <button
+                type="button"
+                onClick={clearImage}
+                className="p-2 bg-white bg-opacity-90 rounded-full shadow hover:bg-opacity-100"
+                title="Remove image"
+              >
+                <X size={20} className="text-red-600" />
+              </button>
+            )}
+          </div>
+        </div>
+        
+        {/* Placeholder overlay when no image */}
+        {isPlaceholder && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center text-gray-400">
+            <ImageIcon size={36} />
+            <span className="mt-2 text-sm">{label}</span>
+          </div>
+        )}
+      </div>
+      
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        onChange={handleFileChange}
+        className="hidden"
+      />
+    </div>
+  );
+}
+
+export default ImageUpload;


### PR DESCRIPTION
This PR implements the image upload functionality as defined in Issue #1.

## Changes
- Added a reusable `ImageUpload` component to handle file selection, image preview, and upload
- Modified the slide data structure to include image information
- Updated the edit modal to show image upload options specific to each slide type
- Added UI controls to upload, preview, and manage images
- Updated the slide rendering to use uploaded images when available

## How to Test
1. Add a new slide from any template
2. Click "Edit Content" on the slide
3. In the edit modal, scroll down to the Images section
4. Upload an image by clicking on the placeholder
5. Save changes and verify the image appears in the slide
6. Try different slide types to verify image upload for each template

## Notes
- Images are stored in state as object URLs, which means they're only persisted during the current session
- For full persistence, additional changes would be needed to save the images (e.g., to localStorage or a server)
- The UI adjusts based on slide type to show appropriate image upload fields